### PR TITLE
Cross-platform conformity

### DIFF
--- a/WASABIGuiQt.pro
+++ b/WASABIGuiQt.pro
@@ -8,7 +8,7 @@
 #QMAKEFEATURES += $$_PRO_FILE_PWD_/WASABI-qwt-clone/qwt-code/qwt
 #QMAKEFEATURES += $$_PRO_FILE_PWD_/WASABIEngine
 QT       += core gui opengl network xml
-CONFIG += qwt
+CONFIG += qwt c++11
 
 TARGET = WASABIGuiQt
 TEMPLATE = app
@@ -19,10 +19,18 @@ INCLUDEPATH +=  $$_PRO_FILE_PWD_/WASABI-qwt-clone/qwt-code/qwt/src
 CONFIG(release, debug|release) {
     win32-g++:LIBS += -L"$$_PRO_FILE_PWD_/build-WASABIEngine/release" -lWASABIEngine
     win32-g++:LIBS += -L"$$_PRO_FILE_PWD_/WASABI-qwt-clone/qwt-code/qwt/lib" -lqwt
+
+    # On Mac, the debug and release folders are not automatically created
+    macx:LIBS += -L"$$_PRO_FILE_PWD_/build-WASABIEngine" -lWASABIEngine
+    macx:LIBS += -L"$$_PRO_FILE_PWD_/WASABI-qwt-clone/qwt-code/qwt/lib" -lqwt
 }
 CONFIG(debug, debug|release) {
     win32-g++:LIBS += -L"$$_PRO_FILE_PWD_/build-WASABIEngine/debug" -lWASABIEngine
     win32-g++:LIBS += -L"$$_PRO_FILE_PWD_/WASABI-qwt-clone/qwt-code/qwt/lib" -lqwtd
+
+    # On Mac, the debug and release folders are not automatically created
+    macx:LIBS += -L"$$_PRO_FILE_PWD_/build-WASABIEngine" -lWASABIEngine
+    macx:LIBS += -L"$$_PRO_FILE_PWD_/WASABI-qwt-clone/qwt-code/qwt/lib" -lqwt
 }
 # win32-g++:LIBS += -L"$$_PRO_FILE_PWD_/WASABI-qwt-clone/qwt-code/qwt/lib" -lqwtmathml
 #win32-g++:LIBS += -lWASABIEngine

--- a/glPADWidget.cpp
+++ b/glPADWidget.cpp
@@ -29,8 +29,13 @@
 
 #include "glPADWidget.h"
 #include "wasabiqtwindow.h"
-#include <GL/gl.h>
-#include <GL/glu.h>
+#ifdef __APPLE__
+    #include <OpenGL/gl.h>
+    #include <OpenGL/glu.h>
+#else
+    #include <GL/gl.h>
+    #include <GL/glu.h>
+#endif
 
 #ifndef GL_MULTISAMPLE
 #define GL_MULTISAMPLE  0x809D

--- a/wasabiqtwindow.cpp
+++ b/wasabiqtwindow.cpp
@@ -1133,15 +1133,13 @@ string WASABIQtWindow::getPackageTimeStamp(){
 }
 
 std::string WASABIQtWindow::buildAffectedLikelihoodStrings(vector<cogaEmotionalAttendee*> attendees, string timeStamp){
-    char buffer[33];
-    itoa(attendees.size(),buffer,10);
     std::string padString;
 
     std::string padStrings = "agents: timeStamp=";
     padStrings += timeStamp;
     padStrings += " ";
     padStrings += "total=";
-    padStrings += buffer;
+    padStrings += std::to_string(attendees.size());
     padStrings += " ";
     std::vector<cogaEmotionalAttendee*>::iterator iter_ea;
     //const char* pEmoMlStr;
@@ -1158,10 +1156,9 @@ std::string WASABIQtWindow::buildAffectedLikelihoodStrings(vector<cogaEmotionalA
         ui->textEditOut->append(QString("(%0) %1: %2").arg(QTime::currentTime().toString())
                             .arg(ea->getName().c_str())
                             .arg(padString.c_str()));
-        //padStrings += std::to_string(ea->getLocalID());
-        itoa(ea->getLocalID(), buffer, 10);
+        
         padStrings += "ID";
-        padStrings += buffer;
+        padStrings += std::to_string(ea->getLocalID());
 
         stringstream padValues;
         padValues << " P=" << ea->getPValue() << " A=" << ea->getAValue() << " D=" << ea->getDValue();


### PR DESCRIPTION
This pull request contains changes to improve on the cross-platform capabilities of the WASABIQtGui project.
Changes contain:
- Addition of `c++11` to the qmake `CONFIG` variable (enables use of `std::to_string()`)
- Addition of the dependency libraries for mac operating systems (`LIBS += ...`)
- Replacement of `itoa()` calls with `std::to_string()` to ensure ISO-C++ conformity (see [this](http://www.cplusplus.com/reference/cstdlib/itoa/#portability))
- Fix of the OpenGL header inclusions for mac operating systems in glPADWidget.cpp

Depending on the compiler being used, the decision to use c++11 could render the current dependencies to _WASABIEngine_ and _WASABI-qwt-clone_ unlinkable. Compilation of the dependency projects in c++11 might become necessary.
